### PR TITLE
KeepAliveTecton implementáció

### DIFF
--- a/fungorium/src/main/java/projlab/fungorium/models/KeepAliveTecton.java
+++ b/fungorium/src/main/java/projlab/fungorium/models/KeepAliveTecton.java
@@ -1,0 +1,53 @@
+package projlab.fungorium.models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Az egy fonalat növesztő Tecton modellje.
+ */
+public final class KeepAliveTecton extends Tecton {
+	/**
+	 * Konstuktor.
+	 */
+	public KeepAliveTecton() {
+		super();
+	}
+
+	/**
+	 * Létrehoz egy új Tectont, aminek nincsenek szomszédjai és nincs rajta semmi.
+	 * 
+	 * @param neighbour Szomszédos tektonok.
+	 */
+	public KeepAliveTecton(List<Tecton> neighbours) {
+		super(neighbours);
+	}
+
+	/**
+	 * Életben tartja az összes tektonra beregisztrált gombafonalat.
+	 */
+	private void keepThreadsAlive() {
+		for (MushroomThread thread : mushroomThreads) {
+			thread.resetTurnsToDie();
+		}
+	}
+
+	@Override
+	public void onEndOfTheRound() {
+		keepThreadsAlive();
+
+		super.onEndOfTheRound();
+	}
+
+	@Override
+	public String getOutputString() {
+		StringBuilder sb = new StringBuilder("KEEPALIVETECTON ");
+		sb.append(getID() + " ");
+		sb.append(neighbours.size() + " ");
+		sb.append(hasBody() ? mushroomBody.getID() + " " : -1 + " ");
+		sb.append(mushroomThreads.size() + " ");
+		sb.append(mushroomSpores.size());
+
+		return sb.toString();
+	}
+}

--- a/fungorium/src/main/java/projlab/fungorium/models/KeepAliveTecton.java
+++ b/fungorium/src/main/java/projlab/fungorium/models/KeepAliveTecton.java
@@ -1,21 +1,23 @@
 package projlab.fungorium.models;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Az egy fonalat növesztő Tecton modellje.
+ * Annak a tektonnak a modellje, ami az összes rajta lévő gombafonalat életben
+ * tartja.
+ * 
+ * @see #keepThreadsAlive()
  */
 public final class KeepAliveTecton extends Tecton {
 	/**
-	 * Konstuktor.
+	 * Konstuktor. Létrehoz egy tektont, aminek nincsenek szomszédjai.
 	 */
 	public KeepAliveTecton() {
 		super();
 	}
 
 	/**
-	 * Létrehoz egy új Tectont, aminek nincsenek szomszédjai és nincs rajta semmi.
+	 * Létrehoz egy új Tectont, a megadott szomszédokkal.
 	 * 
 	 * @param neighbour Szomszédos tektonok.
 	 */


### PR DESCRIPTION
A 8. doksi szerint implementálva lett a KeepAliveTecton (8.1.7).

A keepThreadsAlive nem public, hanem private metódus lett. Ezt még 10.0-ba fel lehet vinni, de nem hiszem hogy észrevenné akárki.