### PR TITLE
Patch view positioning

### DIFF
--- a/fungorium/src/main/java/projlab/fungorium/controllers/GameLayoutGenerator.java
+++ b/fungorium/src/main/java/projlab/fungorium/controllers/GameLayoutGenerator.java
@@ -102,7 +102,7 @@ public class GameLayoutGenerator {
 
 			int radius = (int) (threadTectonView.getSize().x * 0.5 * ThreadView.RADIUS_MULTIPLIER);
 
-			Point position = threadTectonView.calculateMobileObjectPosition(threadTecton, radius);
+			Point position = threadTectonView.calculateMobileObjectPosition(thread, radius);
 
 			threadViewMap.put(thread.getID(), new ThreadView(thread, position));
 		}
@@ -158,7 +158,7 @@ public class GameLayoutGenerator {
 
 			int radius = (int) (insectTectonView.getSize().x * 0.5 * InsectView.RADIUS_MULTIPLIER);
 
-			Point position = insectTectonView.calculateMobileObjectPosition(insectTecton, radius);
+			Point position = insectTectonView.calculateMobileObjectPosition(insect, radius);
 
 			var insectView = new InsectView(insect, position);
 			addView(insectView);
@@ -175,7 +175,7 @@ public class GameLayoutGenerator {
 
 			int radius = (int) (sporeTectonView.getSize().x * 0.5 * SporeView.RADIUS_MULTIPLIER);
 
-			Point position = sporeTectonView.calculateMobileObjectPosition(sporeTecton, radius);
+			Point position = sporeTectonView.calculateMobileObjectPosition(spore, radius);
 
 			addView(new SporeView(spore, position));
 		}

--- a/fungorium/src/main/java/projlab/fungorium/models/GameObjectRegistry.java
+++ b/fungorium/src/main/java/projlab/fungorium/models/GameObjectRegistry.java
@@ -28,6 +28,7 @@ public class GameObjectRegistry {
 	public void unregisterInsect(Insect i) { insects.remove(i); }
 	public void unregisterMushroomSpore(MushroomSpore s) { mushroomSpores.remove(s); }
 	public void unregisterMushroomBody(MushroomBody b) { mushroomBodies.remove(b); }
+	public void unregisterMushroomThread(MushroomThread t) { mushroomThreads.remove(t); }
 
 	public List<Tecton> getTectons() { return tectons; }
 	public List<MushroomBody> getMushroomBodies() { return mushroomBodies; }

--- a/fungorium/src/main/java/projlab/fungorium/models/MushroomThread.java
+++ b/fungorium/src/main/java/projlab/fungorium/models/MushroomThread.java
@@ -65,6 +65,8 @@ public class MushroomThread extends TurnAware implements PrintableState {
             connectedThread.removeConnection(this);
         }
         tecton.removeConnection(this);
+        this.tecton = null;
+        delete();
     }
 
     /**
@@ -319,6 +321,12 @@ public class MushroomThread extends TurnAware implements PrintableState {
         } catch (Exception e) {
             Logger.printError(e.getMessage());
         }
+    }
+
+    @Override 
+    protected void delete() {
+        Game.getInstance().getRegistry().unregisterMushroomThread(this);
+        super.delete();
     }
 
     /*

--- a/fungorium/src/main/java/projlab/fungorium/views/gamecomponents/ThreadView.java
+++ b/fungorium/src/main/java/projlab/fungorium/views/gamecomponents/ThreadView.java
@@ -17,7 +17,7 @@ public class ThreadView extends GameComponentView<MushroomThread> {
     public static final double RADIUS_MULTIPLIER = 0.7;
     private static final Point MUSHROOMTHREAD_SIZE = new Point(32, 32);
     private static final String SPROUT1_Path = "images/SproutThread1.png";
-    private static final String SPROUT2_Path = "images/SproutThread1.png";
+    private static final String SPROUT2_Path = "images/SproutThread2.png";
     private static final String GROWN_PATH = "images/Thread.png";
     private static final String CUT_PATH = "images/CutThread.png";
 
@@ -44,16 +44,15 @@ public class ThreadView extends GameComponentView<MushroomThread> {
     @Override
     public void draw(Graphics2D g) {
         MushroomThread thread = getGameObject();
+
         if (thread.getCutState() == CutState.CUT) {
             image = cutImage;
-        }
-
-        else {
+        } else {
             switch (thread.getGrowState()) {
                 case SPROUT:
                     if (thread.getTurnsToGrow() > 2) {
                         image = sprout1Image;
-                    } else if (thread.getTurnsToGrow() > 1) {
+                    } else if (thread.getTurnsToGrow() >= 1) {
                         image = sprout2Image;
                     }
                     break;
@@ -65,6 +64,10 @@ public class ThreadView extends GameComponentView<MushroomThread> {
                 default:
                     break;
             }
+        }
+
+        if (image == null) {
+            System.out.println();
         }
 
         int startX = center.x - size.x / 2;


### PR DESCRIPTION
- a mobileGameObject-ek lekérése és kirajzolása helytelenül volt paraméterezve
- a MushroomThread leveszi magát a tektonról (.kill()), de a saját referenciáját nem dobja el a tektonhoz, ezért a draw kód megőrül, mert a tekton 0 objektumról tud, pedig őt referálja a MushroomThread.